### PR TITLE
Merge xbuild-1 changes

### DIFF
--- a/Packaging/Dummy.cs
+++ b/Packaging/Dummy.cs
@@ -1,0 +1,32 @@
+﻿//
+//  Dummy.cs
+//
+//  Author:
+//       Roman M. Yagodin <roman.yagodin@gmail.com>
+//
+//  Copyright (c) 2015 Roman M. Yagodin
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+using System;
+
+namespace Packaging
+{
+    public class Dummy
+    {
+        public Dummy ()
+        {
+        }
+    }
+}
+

--- a/Packaging/InstallPackage.targets
+++ b/Packaging/InstallPackage.targets
@@ -1,27 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0" DefaultTargets="Build">
 	<Target Name="MakeInstallPackage" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<!-- Read package version from the manifest -->
-		<XmlRead Prefix="n" Namespace="http://schemas.microsoft.com/developer/msbuild/2003" XPath="/dotnetnuke/packages/package[1]/@version" XmlFileName="..\R7.University\R7.University.dnn">
-			<Output TaskParameter="Value" PropertyName="Version" />
-		</XmlRead>
-		<!-- Declare binaries -->
-		<ItemGroup>
-			<InstallBinaryFiles Include="$(MainProjectOutputPath)\R7.University*.dll" />
+        <!-- Read package version from the manifest -->
+    	<XmlRead Condition=" '$(OS)' != 'Unix' " Prefix="n" Namespace="http://schemas.microsoft.com/developer/msbuild/2003" XPath="/dotnetnuke/packages/package[1]/@version" XmlFileName="..\R7.University\R7.University.dnn">
+    		<Output TaskParameter="Value" PropertyName="Version" />
+    	</XmlRead>
+        <Exec Condition=" '$(OS)' == 'Unix' " Command="xmllint --xpath 'string(/dotnetnuke/packages/package[1]/@version)' ..\R7.University\R7.University.dnn > __version" />
+        <ReadLinesFromFile Condition=" '$(OS)' == 'Unix' " File="__version">
+            <Output TaskParameter="Lines" PropertyName="Version"/>
+        </ReadLinesFromFile>
+        <Delete Condition=" '$(OS)' == 'Unix' " Files="__version" />
+        <!-- Declare binaries -->
+    	<ItemGroup>
+    		<InstallBinaryFiles Include="$(MainProjectOutputPath)\R7.University*.dll" />
             <InstallBinaryFiles Include="$(MainProjectOutputPath)\DotNetNuke.R7.dll" />
             <InstallBinaryFiles Include="$(MainProjectOutputPath)\AjaxControlToolkit.dll" />
-		</ItemGroup>
-		<!-- Declare manifest files -->
-		<ItemGroup>
-			<InstallManifestFiles Include="..\R7.University\*.dnn" />
-			<InstallManifestFiles Include="..\R7.University\License.txt" />
-			<InstallManifestFiles Include="..\R7.University\ReleaseNotes.txt" />
-		</ItemGroup>
-		<!-- Declare SqlDataProvider files -->
-		<ItemGroup>
-			<InstallSqlDataProviderFiles Include="..\R7.University\SqlDataProvider\*.sqldataprovider" />
-		</ItemGroup>
-		<!-- Declare resource files -->
+    	</ItemGroup>
+    	<!-- Declare manifest files -->
+    	<ItemGroup>
+    		<InstallManifestFiles Include="..\R7.University\*.dnn" />
+            <InstallManifestFiles Include="..\R7.University\*.dnn6" />
+    		<InstallManifestFiles Include="..\R7.University\License.txt" />
+        	<InstallManifestFiles Include="..\R7.University\ReleaseNotes.txt" />
+        </ItemGroup>
+    	<!-- Declare SqlDataProvider files -->
+    	<ItemGroup>
+    		<InstallSqlDataProviderFiles Include="..\R7.University\SqlDataProvider\*.SqlDataProvider" />
+        </ItemGroup>
+        <!-- Declare resource files -->
 		<ItemGroup>
 			<InstallResourceFiles Include="..\**\*.ascx" />
 			<InstallResourceFiles Include="..\**\*.aspx" />
@@ -39,46 +45,52 @@
 			<InstallResourceFiles Include="..\**\*.jpg" />
 			<InstallResourceFiles Include="..\**\*.png" />
 			<InstallResourceFiles Include="..\**\*.gif" />
-		</ItemGroup>
-		<!-- Declare excluded files -->
-		<ItemGroup>
-			<InstallExcludeFiles Include="..\Packaging\**" />
-			<InstallExcludeFiles Include="..\**\bin\**" />
-			<InstallExcludeFiles Include="..\**\obj\**" />
-			<InstallExcludeFiles Include="..\**\.git\**" />
-			<InstallExcludeFiles Include="..\**\.svn\**" />
-			<InstallExcludeFiles Include="..\**\_ReSharper*\**" />
-		</ItemGroup>
+        </ItemGroup>
+        <!-- Declare excluded files -->
+        <ItemGroup>
+            <InstallExcludeFiles Include="..\packages\**\*" />
+            <InstallExcludeFiles Include="..\Packaging\**\*" />
+            <InstallExcludeFiles Include="..\.git\**\*" />
+            <InstallExcludeFiles Include="..\.svn\**\*" />
+            <InstallExcludeFiles Include="..\*\bin\**\*" />
+            <InstallExcludeFiles Include="..\*\obj\**\*" />
+            <InstallExcludeFiles Include="..\*\_ReSharper*\**\*" />
+        </ItemGroup>
 		<!-- Apply excluded files filters -->
 		<ItemGroup>
 			<InstallResourceFilteredFiles Include="@(InstallResourceFiles)" Exclude="@(InstallExcludeFiles)" />
 		</ItemGroup>
 		<!-- Copy binaries -->
-		<Copy SourceFiles="@(InstallBinaryFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp_Package\bin" />
+		<Copy SourceFiles="@(InstallBinaryFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp\Package\bin" />
 		<!-- Copy manifest files -->
-		<Copy SourceFiles="@(InstallManifestFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp_Package" />
+		<Copy SourceFiles="@(InstallManifestFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp\Package" />
 		<!-- Copy SqlDataProvider files -->
-		<Copy SourceFiles="@(InstallSqlDataProviderFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp_Package\SqlDataProvider" />
-		<!-- Copy filtered Resource files to tmp_Resources dir -->
-		<Copy SourceFiles="@(InstallResourceFilteredFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp_Resources\%(RecursiveDir)" />
+		<Copy SourceFiles="@(InstallSqlDataProviderFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp\Package\SqlDataProvider" />
+		<!-- Copy filtered Resource files to tmp\Resources dir -->
+		<Copy SourceFiles="@(InstallResourceFilteredFiles)" DestinationFolder="$(MSBuildProjectDirectory)\tmp\Resources\%(RecursiveDir)" />
 		<!-- Declare files to zip -->
 		<ItemGroup>
-			<InstallResourceZipFiles Include="$(MSBuildProjectDirectory)\tmp_Resources\**\*.*" />
+			<InstallResourceZipFiles Include="$(MSBuildProjectDirectory)\tmp\Resources\**\*.*" />
 		</ItemGroup>
-		<!-- Create Resources.zip -->
-		<Zip Files="@(InstallResourceZipFiles)" WorkingDirectory="$(MSBuildProjectDirectory)\tmp_Resources" ZipFileName="Resources.$(PackageExtension)" />
-		<!-- Move Resources.zip to tmp_Package dir -->
-		<Move SourceFiles="$(MSBuildProjectDirectory)\Resources.$(PackageExtension)" DestinationFolder="$(MSBuildProjectDirectory)\tmp_Package/" />
-		<!-- Declare install package files -->
+        <!-- Create Resources.zip -->
+		<Zip Condition=" '$(OS)' != 'Unix' " Files="@(InstallResourceZipFiles)" WorkingDirectory="$(MSBuildProjectDirectory)\tmp\Resources" ZipFileName="Resources.$(PackageExtension)" /> -->
+        <Exec Condition=" '$(OS)' == 'Unix' " Command="zip -r -6 -UN=UTF8 &quot;$(MSBuildProjectDirectory)\Resources.$(PackageExtension)&quot; ." WorkingDirectory="$(MSBuildProjectDirectory)/tmp/Resources" />
+        <!-- Move Resources.zip to tmp\Package dir -->
+		<Copy SourceFiles="$(MSBuildProjectDirectory)\Resources.$(PackageExtension)" DestinationFolder="$(MSBuildProjectDirectory)\tmp\Package\" />
+        <Delete Files="$(MSBuildProjectDirectory)\Resources.$(PackageExtension)" />
+        <!-- Declare install package files -->
 		<ItemGroup>
-			<InstallPackageFiles Include="$(MSBuildProjectDirectory)\tmp_Package\**\*.*" />
+			<InstallPackageFiles Include="$(MSBuildProjectDirectory)\tmp\Package\**\*.*" />
 		</ItemGroup>
 		<!-- Create the install package -->
-		<Zip Files="@(InstallPackageFiles)" WorkingDirectory="$(MSBuildProjectDirectory)\tmp_Package" ZipFileName="$(PackageName)-$(Version)-Install.$(PackageExtension)" />
-		<!-- Copy the install package to the output directory -->
-		<Move SourceFiles="$(MSBuildProjectDirectory)\$(PackageName)-$(Version)-Install.$(PackageExtension)" DestinationFolder="$(PackageOutputPath)/" />
-		<!-- Cleanup -->
-		<RemoveDir Directories="$(MSBuildProjectDirectory)\tmp_Resources" />
-		<RemoveDir Directories="$(MSBuildProjectDirectory)\tmp_Package" />
+		<Zip Condition=" '$(OS)' != 'Unix' " Files="@(InstallPackageFiles)" WorkingDirectory="$(MSBuildProjectDirectory)\tmp\Package" ZipFileName="$(PackageName)-$(Version)-Install.$(PackageExtension)" />
+        <Exec Condition=" '$(OS)' == 'Unix' " Command="zip -r -6 -UN=UTF8 &quot;$(MSBuildProjectDirectory)\$(PackageName)-$(Version)-Install.$(PackageExtension)&quot; ." WorkingDirectory="$(MSBuildProjectDirectory)/tmp/Package" />
+		<!-- Move the install package to the output directory -->
+		<Copy SourceFiles="$(MSBuildProjectDirectory)\$(PackageName)-$(Version)-Install.$(PackageExtension)" DestinationFolder="$(PackageOutputPath)\" />
+        <Delete Files="$(MSBuildProjectDirectory)\$(PackageName)-$(Version)-Install.$(PackageExtension)" />
+        <!-- Cleanup -->
+        <RemoveDir Directories="$(MSBuildProjectDirectory)\tmp\Resources" />
+		<RemoveDir Directories="$(MSBuildProjectDirectory)\tmp\Package" />
+        <RemoveDir Directories="$(MSBuildProjectDirectory)\tmp" />
 	</Target>
 </Project>

--- a/Packaging/LocalDeploy.targets
+++ b/Packaging/LocalDeploy.targets
@@ -1,13 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0" DefaultTargets="Build">
-	<Target Name="DoLocalDeploy" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<!-- Declare binaries -->
-		<ItemGroup>
-			<LocalDeployBinaryFiles Include="$(MainProjectOutputPath)\R7.University*.dll" />
+    <Target Name="DoLocalDeploy" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <!-- Declare binaries -->
+        <ItemGroup>
+            <LocalDeployBinaryFiles Include="$(MainProjectOutputPath)\R7.University*.dll" />
             <LocalDeployBinaryFiles Include="$(MainProjectOutputPath)\DotNetNuke.R7.dll" />
             <LocalDeployBinaryFiles Include="$(MainProjectOutputPath)\AjaxControlToolkit.dll" />
-		</ItemGroup>
+        </ItemGroup>
+        <!-- Declare resource files -->
+        <ItemGroup>
+            <LocalDeployResourceFiles Include="..\**\*.ascx" />
+            <LocalDeployResourceFiles Include="..\**\*.aspx" />
+            <LocalDeployResourceFiles Include="..\**\*.asmx" />
+            <LocalDeployResourceFiles Include="..\**\*.ashx" />
+            <LocalDeployResourceFiles Include="..\**\*.resx" />
+            <LocalDeployResourceFiles Include="..\**\*.css" />
+            <LocalDeployResourceFiles Include="..\**\*.html" />
+            <LocalDeployResourceFiles Include="..\**\*.htm" />
+            <LocalDeployResourceFiles Include="..\**\*.xml" />
+            <LocalDeployResourceFiles Include="..\**\*.xsl" />
+            <LocalDeployResourceFiles Include="..\**\*.xslt" />
+            <LocalDeployResourceFiles Include="..\**\*.resx" />
+            <LocalDeployResourceFiles Include="..\**\*.js" />
+            <LocalDeployResourceFiles Include="..\**\*.jpg" />
+            <LocalDeployResourceFiles Include="..\**\*.png" />
+            <LocalDeployResourceFiles Include="..\**\*.gif" />
+        </ItemGroup>
+        <!-- Declare excluded files -->
+        <ItemGroup>
+            <LocalDeployExcludeFiles Include="..\packages\**\*" />
+            <LocalDeployExcludeFiles Include="..\Packaging\**\*" />
+            <LocalDeployExcludeFiles Include="..\.git\**\*" />
+            <LocalDeployExcludeFiles Include="..\.svn\**\*" />
+            <LocalDeployExcludeFiles Include="..\*\bin\**\*" />
+            <LocalDeployExcludeFiles Include="..\*\obj\**\*" />
+            <LocalDeployExcludeFiles Include="..\*\_ReSharper*\**\*" />
+        </ItemGroup>
+        <!-- Apply excluded files filters -->
+        <ItemGroup>
+            <LocalDeployResourceFilteredFiles Include="@(LocalDeployResourceFiles)" Exclude="@(LocalDeployExcludeFiles)" />
+        </ItemGroup>
         <!-- Copy binaries -->
-		<Copy SourceFiles="@(LocalDeployBinaryFiles)" DestinationFolder="$(DnnBinPath)" />
-	</Target>
+        <Copy SourceFiles="@(LocalDeployBinaryFiles)" DestinationFolder="$(DnnLocalDeployPath)\bin" />
+        <!-- Copy filtered Resource files to tmp\Resources dir -->
+        <Copy SourceFiles="@(LocalDeployResourceFilteredFiles)" DestinationFolder="$(DnnLocalDeployPath)\DesktopModules\R7.University\%(RecursiveDir)" />
+    </Target>
 </Project>

--- a/Packaging/Packaging.csproj
+++ b/Packaging/Packaging.csproj
@@ -35,8 +35,9 @@
     <PackageExtension>zip</PackageExtension>
     <PackageName>R7.University</PackageName>
     <PackageOutputPath>output</PackageOutputPath>
-    <DnnBinPath Condition="'$(DnnBinPath)' == ''">..\..\..\bin</DnnBinPath>
-    <MainProjectOutputPath Condition="'$(MainProjectOutputPath)' == ''">..\R7.University\bin\$(Configuration)</MainProjectOutputPath>
+    <DnnLocalDeployPath Condition="'$(OS)' == 'Unix'">/home/redhound/mnt/dnn</DnnLocalDeployPath>
+    <DnnLocalDeployPath Condition="'$(OS)' != 'Unix'">C:\Dotnetnuke7</DnnLocalDeployPath>
+    <MainProjectOutputPath>..\R7.University\bin\$(Configuration)</MainProjectOutputPath>
   </PropertyGroup>
   <Import Project="InstallPackage.targets" />
   <Import Project="SourcePackage.targets" />

--- a/Packaging/Packaging.csproj
+++ b/Packaging/Packaging.csproj
@@ -30,7 +30,7 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildProgramFiles32)\MSBuild\MSBuildCommunityTasks\MSBuild.Community.Tasks.Targets" />
+  <Import Project="..\packages\MSBuildTasks.1.4.0.128\tools\MSBuild.Community.Tasks.Targets" />
   <PropertyGroup>
     <PackageExtension>zip</PackageExtension>
     <PackageName>R7.University</PackageName>
@@ -41,11 +41,15 @@
   <Import Project="InstallPackage.targets" />
   <Import Project="SourcePackage.targets" />
   <Import Project="LocalDeploy.targets" />
-  <Target Name="AfterBuild" DependsOnTargets="DoLocalDeploy;MakeInstallPackage;MakeSourcePackage" />
+  <Target Name="AfterBuild" DependsOnTargets="DoLocalDeploy;MakeInstallPackage" />
   <ItemGroup>
     <None Include="Packaging.csproj" />
     <None Include="InstallPackage.targets" />
     <None Include="SourcePackage.targets" />
     <None Include="LocalDeploy.targets" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Dummy.cs" />
   </ItemGroup>
 </Project>

--- a/Packaging/packages.config
+++ b/Packaging/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSBuildTasks" version="1.4.0.128" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
This will add support for building project on Mono 4.x and development using MonoDevelop in GNU/Linux environment.

`InstallPackage.targets` script made compatible with `xbuild`, incompatible (currently) `MSBuild.Community.Tasks` tasks as `XmlRead `and `Zip` replaced with `Exec` calls for shell commands (`xmlint` and `zip`) for *nix systems.

`LocalDeploy.targets` script now deploys also module controls (`.ascx`) and resources (`.css`, `.js`, `.resx`, etc.) - this means project source files could be places nearly anywhere and will not depend anymore on DNN install location.